### PR TITLE
Tweak No Redundant Longhand Properties Rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@buildinams/lint",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@buildinams/lint",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@babel/eslint-parser": "^7.19.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@buildinams/lint",
   "description": "BiA's base lint config(s).",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "author": "Build in Amsterdam <development@buildinamsterdam.com> (https://www.buildinamsterdam.com/)",
   "exports": {

--- a/stylelint/index.js
+++ b/stylelint/index.js
@@ -19,10 +19,10 @@ module.exports = {
     // Enable plugin
     "plugin/declaration-block-no-ignored-properties": true,
 
-    // Don't include flex properties in the redundant longhand properties rule
+    // Ignore select properties in the redundant longhand properties rule
     "declaration-block-no-redundant-longhand-properties": [
       true,
-      { ignoreShorthands: ["/flex/"] },
+      { ignoreShorthands: ["/flex/", "/grid/"] },
     ],
 
     // Prevent redundant nesting selectors


### PR DESCRIPTION
Include `grid` as part of ignore.