### PR TITLE
Loosen rules to prevent breaking builds

### DIFF
--- a/eslint/configs/base.js
+++ b/eslint/configs/base.js
@@ -12,24 +12,24 @@ module.exports = {
 
   rules: {
     // Remove unused imports
-    "unused-imports/no-unused-imports": "error",
+    "unused-imports/no-unused-imports": "warn",
 
     // Order exports
-    "simple-import-sort/exports": "error",
+    "simple-import-sort/exports": "warn",
 
     // Makes sure all imports are at the top of the file
-    "import/first": "error",
+    "import/first": "warn",
 
     // Makes sure there's a newline after the imports
-    "import/newline-after-import": "error",
+    "import/newline-after-import": "warn",
 
     // Merge import statements of the same file
-    "import/no-duplicates": "error",
+    "import/no-duplicates": "warn",
 
     // Prevent 'console.log(...)' from being committed
-    "no-console": ["error", { allow: ["warn", "error"] }],
+    "no-console": ["warn", { allow: ["warn", "error"] }],
 
     // Disallow the use of undeclared variables
-    "no-undef": "error",
+    "no-undef": "warn",
   },
 };

--- a/eslint/configs/javascript.js
+++ b/eslint/configs/javascript.js
@@ -2,6 +2,6 @@ module.exports = {
   rules: {
     // Prevent unused variables. Note: This rule can't be used in TypeScript
     // because it errors on type definitions
-    "no-unused-vars": "error",
+    "no-unused-vars": "warn",
   },
 };

--- a/eslint/configs/next.js
+++ b/eslint/configs/next.js
@@ -12,7 +12,7 @@ module.exports = {
 
     // Turn on imports ordering with custom groups
     "simple-import-sort/imports": [
-      "error",
+      "warn",
       {
         groups: [
           // Match 'react', 'next' and external imports

--- a/eslint/configs/prettier.js
+++ b/eslint/configs/prettier.js
@@ -7,6 +7,6 @@ module.exports = {
 
   rules: {
     // Force the use of double quotes when possible
-    quotes: ["error", "double"],
+    quotes: ["warn", "double"],
   },
 };


### PR DESCRIPTION
Want to kick off a discussion about how strict we want to be in enforcing rules. 

Setting rules to "error" will cause builds to break, slowing down work in progress and cluttering PRs.

Would be nice to strike a better balance between enforcing practices and productivity. I'd propose we go for "warn" on rules that are "cosmetic" and don't present a bug.