### PR TITLE
chore: switch npm publish to OIDC auth

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @paulomfj @maikelvdzande @brunotomedev
+* @maikelvdzande @brunotomedev @moritzsalla @MaartenBruggink

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -2,7 +2,11 @@ name: Publish NPM
 
 on:
   release:
-    types: [created]
+    types: [published]
+
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
 
 jobs:
   lint:
@@ -38,8 +42,9 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org/
 
+      - name: Update npm
+        run: npm install -g npm@latest
+
       - run: npm ci
 
       - run: npm publish --access=public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Replace `NPM_TOKEN` secret with OIDC provenance (`id-token: write`)
- Trigger on `published` instead of `created`
- Update npm to latest before publish

Matches [react-storyblok workflow](https://github.com/buildinamsterdam/react-storyblok/blob/main/.github/workflows/publish-npm.yml).

Requires linking the GitHub repo in npm package settings to enable provenance.