### PR TITLE
fix: improve import sort groups

### DIFF
--- a/eslint/configs/next.js
+++ b/eslint/configs/next.js
@@ -9,12 +9,16 @@ module.exports = [
 				"error",
 				{
 					groups: [
-						// Match 'react', 'next' and external imports
+						// Side-effect imports (e.g. "server-only", polyfills)
+						["^\\u0000(?!.*\\.s?css$)"],
+						// React, Next, then external packages
 						["^react", "^next", "^@?\\w"],
-						// Match 'public' and all absolute imports that begin with '_' or '~'
+						// Absolute aliases (public, _, ~)
 						["^public", "[_~].*"],
-						// Match all relative imports that begin with '.'
-						["^\\."],
+						// Relative imports (excluding styles)
+						["^\\.(?!.*\\.s?css$)"],
+						// Style imports (both side-effect and with specifiers)
+						["\\.s?css$"],
 					],
 				},
 			],

--- a/eslint/configs/react.js
+++ b/eslint/configs/react.js
@@ -26,12 +26,16 @@ module.exports = [
 				"error",
 				{
 					groups: [
-						// Match 'react' and external imports
+						// Side-effect imports (e.g. "server-only", polyfills)
+						["^\\u0000(?!.*\\.s?css$)"],
+						// React, then external packages
 						["^react", "^@?\\w"],
-						// Match 'public' and all absolute imports that begin with '_' or '~'
+						// Absolute aliases (public, _, ~)
 						["^public", "[_~].*"],
-						// Match all relative imports that begin with '.'
-						["^\\."],
+						// Relative imports (excluding styles)
+						["^\\.(?!.*\\.s?css$)"],
+						// Style imports (both side-effect and with specifiers)
+						["\\.s?css$"],
 					],
 				},
 			],


### PR DESCRIPTION
## Summary
- Side-effect imports (`server-only`, polyfills) sorted to top
- Style imports (`.css`, `.scss`) sorted to bottom
- Applies to both `react.js` and `next.js` configs